### PR TITLE
fix: harden Claude entrypoint HOME fallback for non-root runtime

### DIFF
--- a/claude-entrypoint.sh
+++ b/claude-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir -p "$HOME"
+HOME_DIR="${HOME:-/home/clide}"
+mkdir -p "$HOME_DIR"
+
+export HOME="$HOME_DIR"
 
 node <<'NODE'
 const fs = require('fs');


### PR DESCRIPTION
### Motivation
- The container was changed to run as an unprivileged `clide` user, and the `claude-entrypoint.sh` script used `set -u` while referencing `$HOME`, which can cause startup failures when `HOME` is not provided by the runtime.
- Add a safe fallback and ensure the directory exists so the Claude config writer never fails in non-root or minimal shell contexts.

### Description
- Add `HOME_DIR="${HOME:-/home/clide}"`, create the directory, and `export HOME="$HOME_DIR"` at the top of `claude-entrypoint.sh` so the Node config writer always has a valid path to write `~/.claude.json`.
- The branch under review also includes the non-root container changes in `Dockerfile` that create the `clide` user, `chown` the `/workspace`, copy `.tmux.conf` with `--chown=clide:clide`, switch to `USER clide`, and perform user-scoped installs (including the Copilot CLI) as that user.
- The change is limited to startup/home handling and preserves the security intent of running as an unprivileged user.

### Testing
- Ran a shell syntax check with `bash -n entrypoint.sh claude-entrypoint.sh`, which succeeded. 
- Attempted `cp .env.example .env && docker compose config --quiet` to validate the compose build, but it failed because `docker` is not available in this environment. 
- Attempted to run `shellcheck` on the entrypoints but the `shellcheck` binary is not present in the runner so that lint step could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a900f5562c8329aad5e32878ed0ebd)