### PR TITLE
Include .env.example files in Docker build context by updating .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,10 @@
 .env
 .env.*
 
+# Keep example env files visible/included for editing and image context docs
+!.env.example
+!*.env.example
+
 # Version control
 .git
 .gitignore


### PR DESCRIPTION
### Motivation
- Ensure example environment files are kept visible and available in the Docker build context for documentation and editing while still excluding actual secret env files.

### Description
- Add negation patterns `!.env.example` and `!*.env.example` to `.dockerignore` and include a clarifying comment so example env files are not excluded by the existing `.env*` rule.

### Testing
- No automated tests were run or modified for this change since it only updates `.dockerignore` and does not affect runtime code or test behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a902438b008329a1da2b870c917340)