### PR TITLE
Add editor/tooling bundle, CLIDE_EDITOR default, and shared vim config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Do NOT set both — OAuth token takes priority and API key will be ignored.
 # ─────────────────────────────────────────────────────────────────────────
 
+# Preferred editor inside the container (sets $EDITOR/$VISUAL)
+# CLIDE_EDITOR=nvim
+
 # Project directory to mount (default: .. i.e. parent directory)
 # PROJECT_DIR=/path/to/your/repo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     gnupg \
     tmux \
+    neovim \
+    vim \
+    nano \
+    fzf \
+    ripgrep \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (official apt repo)
@@ -30,6 +36,21 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+
+# Install lazygit (pinned release)
+RUN LAZYGIT_VERSION="0.50.0" \
+    && ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) LG_ARCH="x86_64" ;; \
+         arm64) LG_ARCH="arm64" ;; \
+         *) echo "Unsupported architecture for lazygit: $ARCH" && exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_${LG_ARCH}.tar.gz" \
+      -o /tmp/lazygit.tar.gz \
+    && tar -xzf /tmp/lazygit.tar.gz -C /tmp lazygit \
+    && install /tmp/lazygit /usr/local/bin/lazygit \
+    && rm -f /tmp/lazygit.tar.gz /tmp/lazygit
 
 # Install ttyd 1.7.7 for web terminal access (pinned — avoid /latest/ surprises)
 RUN ARCH="$(uname -m)" \
@@ -53,6 +74,15 @@ RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/claude-entrypoint.sh
 
 # tmux config — mouse support, sane splits, 256-colour
 COPY --chown=clide:clide .tmux.conf /home/clide/.tmux.conf
+
+# Shared editor defaults for vim and neovim
+COPY vimrc.local /etc/vim/vimrc.local
+RUN mkdir -p /etc/xdg/nvim \
+    && printf "source /etc/vim/vimrc.local\n" > /etc/xdg/nvim/sysinit.vim
+
+ENV CLIDE_EDITOR=nvim \
+    EDITOR=nvim \
+    VISUAL=nvim
 
 # Switch to unprivileged user for user-scoped installs
 USER clide

--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ ANTHROPIC_API_KEY=sk-ant-xxxxx
    CLAUDE_CODE_SIMPLE=0 docker compose run --rm claude
    ```
 
+### Bundled terminal tooling
+
+In addition to the CLIs above, the container includes an editor/tooling bundle aimed at tmux-based workflows:
+
+| Tool | Command |
+|---|---|
+| Neovim | `nvim` |
+| Vim | `vim` |
+| Nano | `nano` |
+| fzf | `fzf` |
+| ripgrep | `rg` |
+| lazygit | `lazygit` |
+| jq | `jq` |
+
+A minimal shared vim config is shipped at `/etc/vim/vimrc.local` and loaded by both vim and neovim (`/etc/xdg/nvim/sysinit.vim` sources it). Defaults include line numbers, syntax highlighting, mouse support, and 2-space indentation.
+
+Set `CLIDE_EDITOR` to control `$EDITOR` and `$VISUAL` inside the container (default: `nvim`).
+
 ### tmux — multi-pane workflows
 
 `tmux` is installed in the container and enabled by default in the **web terminal**. Every browser tab attaches to the same named session (`main`), so refreshing the page re-attaches rather than spawning a fresh shell.

--- a/claude-entrypoint.sh
+++ b/claude-entrypoint.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 mkdir -p "$HOME"
 
+export CLIDE_EDITOR="${CLIDE_EDITOR:-nvim}"
+export EDITOR="$CLIDE_EDITOR"
+export VISUAL="$CLIDE_EDITOR"
+
 node <<'NODE'
 const fs = require('fs');
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ x-base: &base
     CLAUDE_CODE_SIMPLE: ${CLAUDE_CODE_SIMPLE:-1}
     CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
     CLIDE_TMUX: ${CLIDE_TMUX:-}
+    CLIDE_EDITOR: ${CLIDE_EDITOR:-nvim}
+    EDITOR: ${CLIDE_EDITOR:-nvim}
+    VISUAL: ${CLIDE_EDITOR:-nvim}
   volumes:
     - ${PROJECT_DIR:-..}:/workspace
   stdin_open: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+export CLIDE_EDITOR="${CLIDE_EDITOR:-nvim}"
+export EDITOR="$CLIDE_EDITOR"
+export VISUAL="$CLIDE_EDITOR"
+
 # Pre-seed Claude config (auth, onboarding flags) — same as claude-entrypoint.sh
 # This ensures CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY from .env are wired up
 # before any shell session in the web terminal runs `claude`.

--- a/vimrc.local
+++ b/vimrc.local
@@ -1,0 +1,9 @@
+" Minimal shared defaults for vim and neovim
+set number
+syntax on
+set mouse=a
+set tabstop=2
+set shiftwidth=2
+set softtabstop=2
+set expandtab
+set autoindent


### PR DESCRIPTION
### Motivation

- Provide a small editor and terminal tooling bundle inside the container for tmux-based workflows and to make the web terminal immediately useful.
- Standardize the default editor via `CLIDE_EDITOR` so `$EDITOR`/`$VISUAL` are consistent across services and entrypoints.

### Description

- Install editors and handy CLI tools in the image: `neovim`, `vim`, `nano`, `fzf`, `ripgrep`, `jq`, and add `lazygit` (pinned release with architecture handling) in `Dockerfile`.
- Add a minimal shared vim config at `/etc/vim/vimrc.local` and make `nvim` source it via `/etc/xdg/nvim/sysinit.vim` by copying `vimrc.local` and creating the sysinit file.
- Introduce `CLIDE_EDITOR` with defaults set to `nvim` and export it to `EDITOR` and `VISUAL` in `Dockerfile`, `entrypoint.sh`, `claude-entrypoint.sh`, and `docker-compose.yml` so the editor environment is consistent inside the container.
- Pre-seed README and `.env.example` with documentation about the bundled tooling and the `CLIDE_EDITOR` variable.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a901930dd0832998cfb925a11b43cc)