### PR TITLE
feat: add Python 3 dev tooling (pytest + ruff)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,21 @@ RUN ARCH="$(uname -m)" \
 # hadolint ignore=DL3016
 RUN npm install -g @anthropic-ai/claude-code
 
+# Install Python 3 + dev tooling into an isolated venv
+# - python3-venv provides the venv module (not always bundled in minimal images)
+# - /opt/pyenv is world-readable so the unprivileged clide user can run tools
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/pyenv \
+    && /opt/pyenv/bin/pip install --no-cache-dir \
+       pytest \
+       ruff
+
+ENV PATH="/opt/pyenv/bin:${PATH}"
+
 # Create unprivileged user and set up workspace
 RUN useradd -m -s /bin/bash -u 1000 clide \
     && mkdir -p /workspace \

--- a/README.md
+++ b/README.md
@@ -194,3 +194,20 @@ CLIDE_FIREWALL=0
 ### Requirements
 
 The firewall uses `iptables` and requires the `NET_ADMIN` capability, which is already set in `docker-compose.yml`.  If the capability is unavailable (e.g. a restricted runtime), the script emits a warning and continues without blocking any traffic.
+
+## Python dev tooling
+
+The container includes a Python 3 virtual environment at `/opt/pyenv` with the following tools pre-installed and on `PATH`:
+
+| Tool | Purpose |
+|------|---------|
+| `pytest` | Test runner — `pytest tests/` |
+| `ruff` | Linter + formatter — `ruff check .` / `ruff format .` |
+
+To install project dependencies inside the container:
+
+```bash
+pip install -r requirements.txt
+```
+
+The venv is at `/opt/pyenv`; `pip`, `pytest`, and `ruff` are all directly callable without activation.


### PR DESCRIPTION
## Summary

- Installs `python3` and `python3-venv` via apt
- Creates a shared venv at `/opt/pyenv` with `pytest` and `ruff` pre-installed
- Adds `/opt/pyenv/bin` to `PATH` via `ENV` so tools are callable without activation
- Documents the tooling in `README.md`

## Why

Claude Code (and humans) regularly need to run Python test suites and lint code when working on Python repos like `clem` or `teddy`. Without this, getting `pytest` into the container requires manual `pip install` workarounds every session.

## Usage inside container

```bash
pytest tests/          # run tests
ruff check .           # lint
ruff format .          # auto-format
pip install -r requirements.txt  # install project deps into the venv
```

## Test plan

- [ ] Build image: `make build` (or `docker compose build`)
- [ ] Verify `pytest --version` works inside container
- [ ] Verify `ruff --version` works inside container
- [ ] Verify `pip install -r requirements.txt` works on a Python project

🤖 Generated with [Claude Code](https://claude.com/claude-code)