### PR TITLE
fix: pass through arguments for ./clide codex command

### DIFF
--- a/clide
+++ b/clide
@@ -16,7 +16,7 @@ Commands:
   copilot     Run GitHub Copilot CLI
   gh [args]   Run GitHub CLI (pass args after)
   claude      Run Claude Code CLI
-  codex       Run Codex CLI (OpenAI)
+  codex [args] Run Codex CLI (OpenAI; pass args after)
   build       Build the Docker image
   rebuild     Rebuild the Docker image (no cache)
   logs        Follow web terminal logs
@@ -30,6 +30,7 @@ Examples:
   ./clide gh repo view           # run gh with args
   PROJECT_DIR=~/myrepo ./clide shell  # mount a specific project
   ./clide codex                  # run Codex CLI (OpenAI)
+  ./clide codex auth login --auth device
 EOF
 }
 
@@ -76,8 +77,9 @@ case "${1:-help}" in
     CLAUDE_CODE_SIMPLE=1 docker compose run --rm claude
     ;;
   codex)
+    shift
     splash
-    docker compose run --rm codex
+    docker compose run --rm codex "$@"
     ;;
   build)
     docker compose build


### PR DESCRIPTION
### Motivation

- Add support for the OpenAI Codex CLI inside the container and document authentication options (API key or device-code OAuth). 
- Ensure the `./clide codex` wrapper forwards positional arguments so subcommands and flags (for example `auth login --auth device`) execute as expected.

### Description

- Install Codex CLI in the image by adding `npm install -g @openai/codex` to the `Dockerfile`. 
- Expose `OPENAI_API_KEY` in `docker-compose.yml`, add a `codex` service entry, and whitelist `api.openai.com` and `auth.openai.com` in `firewall.sh`. 
- Update documentation and examples in `README.md` and `.env.example` to describe `OPENAI_API_KEY` and device-code auth usage. 
- Fix the `clide` wrapper so the `codex` case `shift`s the selector and runs `docker compose run --rm codex "$@"`, and update the help text and examples to show argument pass-through.

### Testing

- Ran shell syntax check with `bash -n clide`, which succeeded. 
- Verified usage output with `./clide help` to confirm the updated help text and example were printed. 
- Confirmed the `clide` wrapper forwards arguments by inspecting the updated `clide` script and the `codex` case handler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab658cb5cc8329b855ca73cb2047a7)