### PR TITLE
Migrate Claude session data from named volumes to workspace directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,12 +62,13 @@ CADDY_TLS=internal
 # CADDY_BASICAUTH_HASH=$2a$14$xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # ── Session memory ─────────────────────────────────────────────────────────
-# Claude Code session memory (~/.claude) is persisted in a named Docker volume
-# (claude-data) and survives container restarts automatically.
+# Claude Code session memory (~/.claude) is persisted in /workspace/.clide/
+# within the bind-mounted project directory. No Docker named volumes are used,
+# so there are no root-ownership permission issues.
 #
 # CLAUDE.md template: on first run, if /workspace/CLAUDE.md does not exist,
 # the entrypoint copies a template into it. Override the default by placing
-# your own template at: <your-project>/.claude/CLAUDE.md.template
+# your own template at: <your-project>/.clide/CLAUDE.md.template
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── GitLab CLI (glab) ────────────────────────────────────────────────────────

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -9,7 +9,7 @@ with Claude Code, GitHub Copilot, GitHub CLI, and Codex pre-installed.
 - You are running as user `clide` (uid 1001)
 - Egress is restricted to an allowlist (see firewall.sh)
 - Python venv is at `/opt/pyenv` (pytest and ruff pre-installed)
-- Session memory persists across container restarts in `~/.claude/`
+- Session memory persists across container restarts in `/workspace/.clide/`
 
 ## Conventions
 

--- a/claude-entrypoint.sh
+++ b/claude-entrypoint.sh
@@ -15,14 +15,39 @@ if [[ "${CLIDE_FIREWALL_DONE:-0}" != "1" ]]; then
   export CLIDE_FIREWALL_DONE=1
 fi
 
+# Persistent data directory — stored inside the workspace bind mount so
+# everything lives alongside the project (no Docker named volumes needed).
+CLIDE_DIR="/workspace/.clide"
+mkdir -p "$CLIDE_DIR"
+chown clide:clide "$CLIDE_DIR"
+
+# Symlink ~/.claude → /workspace/.clide so Claude Code reads/writes into the
+# workspace-local directory.  Remove any stale file/dir first (e.g. from a
+# previous named-volume mount).
+if [[ -L "$HOME_DIR/.claude" ]]; then
+  # Already a symlink — verify target
+  if [[ "$(readlink "$HOME_DIR/.claude")" != "$CLIDE_DIR" ]]; then
+    rm -f "$HOME_DIR/.claude"
+    ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
+  fi
+elif [[ -d "$HOME_DIR/.claude" ]]; then
+  # Migrate existing data from old named-volume mount into workspace
+  cp -a "$HOME_DIR/.claude/." "$CLIDE_DIR/" 2>/dev/null || true
+  rm -rf "$HOME_DIR/.claude"
+  ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
+else
+  ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
+fi
+chown -h clide:clide "$HOME_DIR/.claude"
+
 # Seed CLAUDE.md into the workspace if a template exists and no CLAUDE.md is present.
 # This gives every session a baseline set of instructions without overwriting user edits.
-# Template search order: /workspace/.claude/CLAUDE.md.template, then bundled default.
+# Template search order: /workspace/.clide/CLAUDE.md.template, then bundled default.
 CLAUDE_MD="/workspace/CLAUDE.md"
 if [[ ! -f "$CLAUDE_MD" ]]; then
   TEMPLATE=""
-  if [[ -f "/workspace/.claude/CLAUDE.md.template" ]]; then
-    TEMPLATE="/workspace/.claude/CLAUDE.md.template"
+  if [[ -f "/workspace/.clide/CLAUDE.md.template" ]]; then
+    TEMPLATE="/workspace/.clide/CLAUDE.md.template"
   elif [[ -f "/usr/local/share/clide/CLAUDE.md.template" ]]; then
     TEMPLATE="/usr/local/share/clide/CLAUDE.md.template"
   fi
@@ -32,9 +57,6 @@ if [[ ! -f "$CLAUDE_MD" ]]; then
     echo "claude: seeded CLAUDE.md from ${TEMPLATE}"
   fi
 fi
-
-# Ensure the persistent volume directory is owned by clide (first-run fix for named volumes)
-chown -R clide:clide "$HOME_DIR/.claude" 2>/dev/null || true
 
 gosu clide node <<'NODE'
 const fs = require('fs');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ x-base: &base
   pids_limit: 512
   volumes:
     - ${PROJECT_DIR:-..}:/workspace
-    - claude-data:/home/clide/.claude
   stdin_open: true
   tty: true
 
@@ -79,7 +78,6 @@ services:
     entrypoint: ["/usr/local/bin/firewall.sh"]
     command: ["codex"]
 
-# Named volumes — persist state across container restarts.
-# claude-data: Claude Code session memory, settings, and project learnings (~/.claude)
-volumes:
-  claude-data:
+# Persistent state is stored in /workspace/.clide/ (within the bind-mounted
+# project directory) — no named volumes needed. This avoids Docker's
+# root-owned volume permission issues and keeps all clide data in one place.


### PR DESCRIPTION
## Summary
This change migrates Claude Code session data storage from Docker named volumes to a workspace-local directory (`/workspace/.clide/`), eliminating permission issues and keeping all project-related data in one place.

## Key Changes
- **New persistent data directory**: Created `/workspace/.clide/` within the bind-mounted workspace to store Claude session data instead of using Docker named volumes
- **Symlink management**: Added logic to create and maintain a symlink from `~/.claude` to `/workspace/.clide/`, with migration support for existing data from previous named-volume setups
- **Removed named volume**: Deleted the `claude-data` named volume from docker-compose.yml and its associated volume declaration
- **Updated documentation**: Updated comments and template references throughout to reflect the new `.clide/` directory location
- **Ownership handling**: Ensured proper file ownership for the clide user on the new directory structure

## Implementation Details
The entrypoint script now:
1. Creates the `.clide/` directory with proper ownership
2. Intelligently handles the symlink creation with three cases:
   - If symlink already exists and points to the correct location, leaves it alone
   - If a directory exists at `~/.claude/`, migrates its contents to `.clide/` and replaces it with a symlink
   - If nothing exists, creates the symlink directly
3. Maintains backward compatibility with existing setups while preventing stale mounts

This approach eliminates Docker's root-ownership permission issues with named volumes while keeping all clide-related data alongside the project files.

https://claude.ai/code/session_01CvrggoLEZAcjJaoQFggHs9