### PR TITLE
Make entrypoint resilient to permission changes on restricted filesystems

### DIFF
--- a/claude-entrypoint.sh
+++ b/claude-entrypoint.sh
@@ -19,7 +19,12 @@ fi
 # everything lives alongside the project (no Docker named volumes needed).
 CLIDE_DIR="/workspace/.clide"
 mkdir -p "$CLIDE_DIR"
-chown clide:clide "$CLIDE_DIR"
+chown clide:clide "$CLIDE_DIR" 2>/dev/null || {
+  # chown may fail on bind mounts without CHOWN capability or on filesystems
+  # that don't support ownership changes (NFS, FUSE, etc.).  Fall back to
+  # world-writable so the clide user can still read/write the directory.
+  chmod 777 "$CLIDE_DIR" 2>/dev/null || echo "warning: cannot set permissions on $CLIDE_DIR" >&2
+}
 
 # Symlink ~/.claude → /workspace/.clide so Claude Code reads/writes into the
 # workspace-local directory.  Remove any stale file/dir first (e.g. from a
@@ -38,7 +43,7 @@ elif [[ -d "$HOME_DIR/.claude" ]]; then
 else
   ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
 fi
-chown -h clide:clide "$HOME_DIR/.claude"
+chown -h clide:clide "$HOME_DIR/.claude" 2>/dev/null || true
 
 # Seed CLAUDE.md into the workspace if a template exists and no CLAUDE.md is present.
 # This gives every session a baseline set of instructions without overwriting user edits.
@@ -53,7 +58,7 @@ if [[ ! -f "$CLAUDE_MD" ]]; then
   fi
   if [[ -n "$TEMPLATE" ]]; then
     cp "$TEMPLATE" "$CLAUDE_MD"
-    chown clide:clide "$CLAUDE_MD"
+    chown clide:clide "$CLAUDE_MD" 2>/dev/null || true
     echo "claude: seeded CLAUDE.md from ${TEMPLATE}"
   fi
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ x-base: &base
     - NET_ADMIN
     - SETUID
     - SETGID
+    - CHOWN
+    - FOWNER
   # Prevent processes from gaining new privileges via setuid/setgid binaries.
   security_opt:
     - no-new-privileges:true


### PR DESCRIPTION
## Summary
This PR improves the robustness of the Claude entrypoint script by gracefully handling permission-related failures that occur on restricted filesystems (NFS, FUSE, bind mounts without CHOWN capability, etc.).

## Key Changes
- **Entrypoint script (`claude-entrypoint.sh`)**:
  - Wrapped the initial `chown` call on `$CLIDE_DIR` with error handling that falls back to `chmod 777` if ownership change fails
  - Added informative comments explaining why `chown` may fail on certain filesystems
  - Changed subsequent `chown` calls to suppress errors with `2>/dev/null || true` pattern for non-critical operations
  - Ensures the clide user can still read/write directories even when ownership cannot be changed

- **Docker Compose configuration (`docker-compose.yml`)**:
  - Added `CHOWN` and `FOWNER` capabilities to the base service configuration
  - These capabilities allow the container to change file ownership and bypass permission checks, enabling proper operation on more filesystem types

## Implementation Details
The changes follow a defensive programming approach:
1. The primary `$CLIDE_DIR` setup attempts `chown` first, then falls back to world-writable permissions if that fails
2. Secondary `chown` operations (symlink, CLAUDE.md) silently ignore failures since they're not critical to functionality
3. Docker capabilities are expanded to support more filesystem scenarios while maintaining security constraints (no-new-privileges still enforced)

This allows the entrypoint to work reliably across different deployment environments without requiring manual permission fixes.

https://claude.ai/code/session_01JrufWPKGMLtHPmCks8kj9A