### PR TITLE
fix: pin all dependency versions in Dockerfile

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,2 @@
 ignore:
   - DL3008  # apt-get version pinning — base tools from official repos, acceptable unpinned
-  - DL3016  # npm version pinning — claude-code and copilot-cli track latest intentionally

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,14 @@ RUN ARCH="$(uname -m)" \
        -o /usr/local/bin/ttyd \
     && chmod +x /usr/local/bin/ttyd
 
-# Install Claude Code CLI (unpinned — tracks new features intentionally)
-# hadolint ignore=DL3016
-RUN npm install -g @anthropic-ai/claude-code
+# Install Claude Code CLI (pinned — bump ARG to upgrade)
+ARG CLAUDE_CODE_VERSION=2.1.71
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
-# Install Codex CLI (unpinned — tracks new features intentionally)
-# hadolint ignore=DL3016,DL3059
-RUN npm install -g @openai/codex
+# Install Codex CLI (pinned — bump ARG to upgrade)
+# hadolint ignore=DL3059
+ARG CODEX_VERSION=0.112.0
+RUN npm install -g "@openai/codex@${CODEX_VERSION}"
 
 # Install glab (GitLab CLI) — pinned version, single binary
 ARG GLAB_VERSION=1.47.0
@@ -67,8 +68,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && python3 -m venv /opt/pyenv \
     && /opt/pyenv/bin/pip install --no-cache-dir \
-       pytest \
-       ruff
+       pytest==9.0.2 \
+       ruff==0.15.5
 
 ENV PATH="/opt/pyenv/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- Pin `@anthropic-ai/claude-code` (2.1.71) and `@openai/codex` (0.112.0) via build ARGs
- Pin `pytest` (9.0.2) and `ruff` (0.15.5) in pip install
- Remove DL3016 hadolint ignore (no longer needed)

Closes #7

## Notes
- All npm versions use `ARG` so bumping is a one-line change (same pattern as `GLAB_VERSION`)
- apt packages remain unpinned (DL3008 ignore kept) — Ubuntu repo versions change with every mirror sync, pinning them breaks builds
- Copilot CLI (`gh.io/copilot-install`) has no version mechanism — installed as a gh extension via upstream script

## Test plan
- [ ] `docker compose build` succeeds
- [ ] `docker compose run --rm shell claude --version` shows 2.1.71
- [ ] `docker compose run --rm shell codex --version` shows 0.112.0
- [ ] `docker compose run --rm shell pytest --version` shows 9.0.2
- [ ] `docker compose run --rm shell ruff --version` shows 0.15.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)