### PR TITLE
fix: create ~/.claude symlink as clide user instead of root

### DIFF
--- a/claude-entrypoint.sh
+++ b/claude-entrypoint.sh
@@ -27,23 +27,23 @@ chown clide:clide "$CLIDE_DIR" 2>/dev/null || {
 }
 
 # Symlink ~/.claude → /workspace/.clide so Claude Code reads/writes into the
-# workspace-local directory.  Remove any stale file/dir first (e.g. from a
-# previous named-volume mount).
+# workspace-local directory.  Run as clide since /home/clide is owned by the
+# clide user and root may lack DAC_OVERRIDE to write there.
+# Remove any stale file/dir first (e.g. from a previous named-volume mount).
 if [[ -L "$HOME_DIR/.claude" ]]; then
   # Already a symlink — verify target
   if [[ "$(readlink "$HOME_DIR/.claude")" != "$CLIDE_DIR" ]]; then
-    rm -f "$HOME_DIR/.claude"
-    ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
+    gosu clide rm -f "$HOME_DIR/.claude"
+    gosu clide ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
   fi
 elif [[ -d "$HOME_DIR/.claude" ]]; then
   # Migrate existing data from old named-volume mount into workspace
   cp -a "$HOME_DIR/.claude/." "$CLIDE_DIR/" 2>/dev/null || true
-  rm -rf "$HOME_DIR/.claude"
-  ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
+  gosu clide rm -rf "$HOME_DIR/.claude"
+  gosu clide ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
 else
-  ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
+  gosu clide ln -s "$CLIDE_DIR" "$HOME_DIR/.claude"
 fi
-chown -h clide:clide "$HOME_DIR/.claude" 2>/dev/null || true
 
 # Seed CLAUDE.md into the workspace if a template exists and no CLAUDE.md is present.
 # This gives every session a baseline set of instructions without overwriting user edits.


### PR DESCRIPTION
## Summary
- Run symlink operations in `/home/clide/` as clide user via `gosu` instead of root
- Root can't write to clide-owned `/home/clide` without `DAC_OVERRIDE`, and cached images without the capability fail at `ln -s`

## Context
Follow-up to #66. The `mkdir /workspace/.clide` fix (DAC_OVERRIDE) works, but the symlink creation in `/home/clide/` still fails because that directory is owned by clide, not root. Running as clide is the correct fix — these are clide's files in clide's home.

## Test plan
- [ ] `docker compose build && docker compose up web` — no permission errors
- [ ] `docker exec clide-web-1 ls -la /home/clide/.claude` shows symlink to `/workspace/.clide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)