### PR TITLE
feat: switch Claude Code to native installer (self-updating)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,6 @@ RUN ARCH="$(uname -m)" \
        -o /usr/local/bin/ttyd \
     && chmod +x /usr/local/bin/ttyd
 
-# Install Claude Code CLI (pinned — bump ARG to upgrade)
-ARG CLAUDE_CODE_VERSION=2.1.71
-RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
-
 # Install Codex CLI (pinned — bump ARG to upgrade)
 # hadolint ignore=DL3059
 ARG CODEX_VERSION=0.112.0
@@ -71,7 +67,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        pytest==9.0.2 \
        ruff==0.15.5
 
-ENV PATH="/opt/pyenv/bin:${PATH}"
+ENV PATH="/home/clide/.local/bin:/opt/pyenv/bin:${PATH}"
 
 # Create unprivileged user and set up workspace
 # UID/GID default to 1000 (standard first non-root user on Linux/macOS).
@@ -99,6 +95,10 @@ COPY --chown=clide:clide .tmux.conf /home/clide/.tmux.conf
 
 # Switch to unprivileged user for user-scoped installs
 USER clide
+
+# Install Claude Code CLI via native installer (self-updating, no npm dependency).
+# Installs to ~/.local/bin/claude — auto-updates at runtime without sudo.
+RUN curl -fsSL https://claude.ai/install.sh | sh
 
 # Trust all directories for git operations.
 # Clide is a single-user dev sandbox — volume-mounted repos from the host


### PR DESCRIPTION
## Summary

- Replace `npm install -g @anthropic-ai/claude-code@2.1.71` with the official native installer (`curl -fsSL https://claude.ai/install.sh | sh`)
- Binary installs to `~/.local/bin/claude` as the `clide` user — fully writable, self-updating at runtime
- Eliminates the "auto-update failed — reinstall node without sudo or use native installer" error
- No more version pinning or container rebuilds needed for Claude updates
- Node.js + npm retained for Codex CLI and entrypoint config scripts

## What changes

| Before | After |
|--------|-------|
| `npm install -g @anthropic-ai/claude-code@2.1.71` (root-owned, update needs sudo) | `curl -fsSL https://claude.ai/install.sh \| sh` (user-owned, self-updating) |
| Binary at `/usr/lib/node_modules/.bin/claude` | Binary at `/home/clide/.local/bin/claude` |
| Pinned version, bump ARG to upgrade | Always gets latest on rebuild; auto-updates between rebuilds |

## Why this is safe

- `~/.local/bin/claude` (the binary) is separate from `~/.claude/` (the config/data dir that gets symlinked to `/workspace/.clide`)
- PATH updated to include `~/.local/bin` before other entries
- Entrypoint scripts invoke `claude` by name (lines 141/144 in `claude-entrypoint.sh`) — resolves via PATH, no hardcoded path
- Codex CLI stays on npm — unaffected

## Test plan

- [x] `docker compose build` succeeds (native installer runs during build)
- [x] `docker compose run --rm claude --version` shows latest Claude Code version
- [ ] `docker compose run --rm shell` → `claude --version` works
- [ ] `claude doctor` reports no update issues
- [ ] Web terminal (`docker compose up web`) → `claude` launches correctly
- [ ] Auto-update succeeds when a new version is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)