### PR TITLE
fix: deployment friction on smaller VPS (#82)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,10 @@ GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # ─────────────────────────────────────────────────────────────────────────
 
 # Container user UID/GID — should match your host user for bind mount permissions.
-# Default 1000 works for most Linux/macOS setups. Override if your UID differs:
-#   CLIDE_UID=$(id -u) CLIDE_GID=$(id -g) docker compose build
-# CLIDE_UID=1000
-# CLIDE_GID=1000
+# Default 1100 avoids common conflicts (GID 1000 is often 'docker' on Ubuntu).
+# Override if needed:  CLIDE_UID=$(id -u) CLIDE_GID=$(id -g) docker compose build
+# CLIDE_UID=1100
+# CLIDE_GID=1100
 
 # Project directory to mount (default: .. i.e. parent directory)
 # PROJECT_DIR=/path/to/your/repo
@@ -44,6 +44,18 @@ GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # GIT_AUTHOR_EMAIL=you@users.noreply.github.com
 # GIT_COMMITTER_NAME=Your Name
 # GIT_COMMITTER_EMAIL=you@users.noreply.github.com
+
+# ── Resource limits ─────────────────────────────────────────────────────────
+# Defaults are safe for 2-core VPS. Increase on beefier hosts.
+# CLIDE_CPUS=2.0
+# CLIDE_MEM_LIMIT=4g
+# CLIDE_PIDS_LIMIT=512
+
+# ── Network binding ────────────────────────────────────────────────────────
+# Bind address for the web terminal. Default: all interfaces.
+# Set to a Tailscale IP to restrict to VPN only:
+# CLIDE_BIND=100.x.x.x
+# CLIDE_BIND=0.0.0.0
 
 # Web terminal (ttyd) configuration
 TTYD_PORT=7681

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PATH="/home/clide/.local/bin:/opt/pyenv/bin:${PATH}"
 
 # Create unprivileged user and set up workspace
-# UID/GID default to 1000 (standard first non-root user on Linux/macOS).
-# Override at build time:  CLIDE_UID=$(id -u) CLIDE_GID=$(id -g) docker compose build
-ARG CLIDE_UID=1000
-ARG CLIDE_GID=1000
+# UID/GID default to 1100 to avoid conflicts with common host groups
+# (GID 1000 is often 'docker' on Ubuntu). Override in .env or at build time:
+#   CLIDE_UID=$(id -u) CLIDE_GID=$(id -g) docker compose build
+ARG CLIDE_UID=1100
+ARG CLIDE_GID=1100
 RUN groupadd -g "${CLIDE_GID}" clide 2>/dev/null || groupmod -n clide "$(getent group "${CLIDE_GID}" | cut -d: -f1)" \
     && useradd -m -l -s /bin/bash -u "${CLIDE_UID}" -g clide clide \
     && mkdir -p /workspace \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ x-base: &base
   build:
     context: .
     args:
-      CLIDE_UID: ${CLIDE_UID:-1000}
-      CLIDE_GID: ${CLIDE_GID:-1000}
+      CLIDE_UID: ${CLIDE_UID:-1100}
+      CLIDE_GID: ${CLIDE_GID:-1100}
       BUILD_VERSION: ${BUILD_VERSION:-dev}
   image: clide
   env_file: .env
@@ -42,9 +42,11 @@ x-base: &base
   security_opt:
     - no-new-privileges:true
   # Resource guardrails — prevent runaway AI workloads from starving the host.
-  mem_limit: 4g
-  cpus: '4.0'
-  pids_limit: 512
+  # Override via .env: CLIDE_MEM_LIMIT, CLIDE_CPUS, CLIDE_PIDS_LIMIT
+  # Use '2.0' on 2-core VPS, '4.0' on 4+ core hosts.
+  mem_limit: ${CLIDE_MEM_LIMIT:-4g}
+  cpus: '${CLIDE_CPUS:-2.0}'
+  pids_limit: ${CLIDE_PIDS_LIMIT:-512}
   volumes:
     - ${PROJECT_DIR:-..}:/workspace
   stdin_open: true
@@ -62,7 +64,7 @@ services:
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     command: []
     ports:
-      - "${TTYD_PORT:-7681}:7681"
+      - "${CLIDE_BIND:-0.0.0.0}:${TTYD_PORT:-7681}:7681"
     labels:
       # Caddy Docker Proxy labels (only active if on caddy network)
       caddy: ${CADDY_HOSTNAME:-clide.lan.wubi.sh}


### PR DESCRIPTION
## Summary
- **UID/GID default** changed from 1000 → 1100 (avoids Docker group GID 1000 conflict on Ubuntu)
- **CPU limit** configurable via `CLIDE_CPUS` env var (default: `2.0`, was hardcoded `4.0`)
- **Memory limit** configurable via `CLIDE_MEM_LIMIT` (default: `4g`)
- **Port binding** configurable via `CLIDE_BIND` (default: `0.0.0.0`, set to Tailscale IP for VPN-only)
- `.env.example` updated with all new vars and docs

Closes #82

## Test plan
- [x] Verified all three issues on forge-edge (2-core, 3.8GB IONOS VPS)
- [ ] CI checks pass
- [ ] Build succeeds with default values on a fresh host

🤖 Generated with [Claude Code](https://claude.com/claude-code)