### PR TITLE
feat: optional intercepting proxy for agent traffic (#50)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,4 +112,8 @@ CADDY_TLS=internal
 #
 # Egress audit — log all outbound connections to .clide/logs/egress.jsonl:
 # CLIDE_EGRESS_AUDIT=1
+#
+# Intercepting proxy — capture full HTTP(S) request/response to .clide/logs/intercept.jsonl:
+# CLIDE_INTERCEPT=1
+# CLIDE_INTERCEPT_BODIES=1   # also capture request/response bodies (large!)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && python3 -m venv /opt/pyenv \
     && /opt/pyenv/bin/pip install --no-cache-dir \
        pytest==9.0.2 \
-       ruff==0.15.5
+       ruff==0.15.5 \
+       mitmproxy==11.1.3
 
 ENV PATH="/home/clide/.local/bin:/opt/pyenv/bin:${PATH}"
 
@@ -92,7 +93,9 @@ COPY scripts/session-logger.sh /usr/local/bin/session-logger.sh
 COPY scripts/notify.sh /usr/local/bin/notify.sh
 COPY scripts/token-cost.py /usr/local/bin/token-cost.py
 COPY scripts/egress-audit.sh /usr/local/bin/egress-audit.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/claude-entrypoint.sh /usr/local/bin/firewall.sh /usr/local/bin/session-logger.sh /usr/local/bin/notify.sh /usr/local/bin/token-cost.py /usr/local/bin/egress-audit.sh
+COPY scripts/intercept-proxy.py /usr/local/bin/intercept-proxy.py
+COPY scripts/intercept-start.sh /usr/local/bin/intercept-start.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/claude-entrypoint.sh /usr/local/bin/firewall.sh /usr/local/bin/session-logger.sh /usr/local/bin/notify.sh /usr/local/bin/token-cost.py /usr/local/bin/egress-audit.sh /usr/local/bin/intercept-start.sh /usr/local/bin/intercept-proxy.py
 
 # Default CLAUDE.md template — seeded into /workspace on first run if none exists
 COPY CLAUDE.md.template /usr/local/share/clide/CLAUDE.md.template

--- a/claude-entrypoint.sh
+++ b/claude-entrypoint.sh
@@ -149,6 +149,17 @@ fi
 # Web terminal always uses tmux via entrypoint.sh; this covers make shell / ./clide shell.
 # Drop privileges to clide via gosu before exec so the workload never runs as root.
 
+# Start intercepting proxy if enabled (captures all HTTP(S) traffic to JSONL).
+# Must start before the agent so proxy env vars are inherited.
+if [[ "${CLIDE_INTERCEPT:-0}" == "1" ]]; then
+  /usr/local/bin/intercept-start.sh
+  # Source the proxy env vars so the agent uses the proxy
+  if [[ -f /tmp/.clide-proxy-env ]]; then
+    # shellcheck disable=SC1091
+    . /tmp/.clide-proxy-env
+  fi
+fi
+
 # Wrap agent CLIs with session logger for structured logging + transcript capture.
 # Set CLIDE_LOG_DISABLED=1 to skip. Logger is agent-agnostic — works with claude, codex, etc.
 AGENT_CMD="${*:-claude}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ x-base: &base
     CLIDE_NTFY_DISABLED: ${CLIDE_NTFY_DISABLED:-}
     # Egress audit — log outbound connections to JSONL (v4: Agent Observability)
     CLIDE_EGRESS_AUDIT: ${CLIDE_EGRESS_AUDIT:-0}
+    # Intercepting proxy — capture full HTTP(S) requests/responses (v4)
+    CLIDE_INTERCEPT: ${CLIDE_INTERCEPT:-0}
+    CLIDE_INTERCEPT_BODIES: ${CLIDE_INTERCEPT_BODIES:-0}
     # LAN CA certificate (e.g. Caddy internal TLS root)
     CLIDE_CA_URL: ${CLIDE_CA_URL:-}
   # Drop all capabilities then re-add only what entrypoint + firewall need.

--- a/scripts/intercept-proxy.py
+++ b/scripts/intercept-proxy.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Intercepting proxy addon for mitmproxy — logs all HTTP(S) traffic to JSONL.
+
+Captures request/response metadata (not full bodies by default) and writes
+structured events to a JSONL file for audit and research.
+
+Usage:
+    mitmdump --listen-port 8080 -s intercept-proxy.py
+
+Output:
+    $CLIDE_LOG_DIR/intercept.jsonl (default: /workspace/.clide/logs/intercept.jsonl)
+
+Environment:
+    CLIDE_LOG_DIR           Log directory
+    CLIDE_INTERCEPT_BODIES  Set to '1' to capture request/response bodies (large!)
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+from mitmproxy import http
+
+
+LOG_DIR = os.environ.get("CLIDE_LOG_DIR", "/workspace/.clide/logs")
+LOG_FILE = Path(LOG_DIR) / "intercept.jsonl"
+CAPTURE_BODIES = os.environ.get("CLIDE_INTERCEPT_BODIES", "0") == "1"
+
+# Ensure log dir exists
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+# Secret patterns to redact from logged content
+SECRET_PATTERNS = [
+    "sk-ant-",       # Anthropic API keys
+    "sk-",           # OpenAI API keys
+    "ghp_",          # GitHub PATs
+    "github_pat_",   # GitHub fine-grained PATs
+    "glpat-",        # GitLab PATs
+    "Bearer ",       # Auth headers
+]
+
+
+def _redact(text: str) -> str:
+    """Redact known secret patterns from text."""
+    for pat in SECRET_PATTERNS:
+        if pat in text:
+            # Find the secret value and redact it
+            idx = text.find(pat)
+            # Redact until whitespace, quote, or end of string
+            end = idx + len(pat)
+            while end < len(text) and text[end] not in (' ', '"', "'", '\n', '\r', ',', '}'):
+                end += 1
+            text = text[:idx] + f"[REDACTED:{pat.rstrip()}...]" + text[end:]
+    return text
+
+
+def _safe_headers(headers) -> dict:
+    """Extract headers as dict, redacting sensitive values."""
+    result = {}
+    sensitive_keys = {"authorization", "x-api-key", "cookie", "set-cookie",
+                      "proxy-authorization", "x-forwarded-for"}
+    for key, val in headers.items():
+        if key.lower() in sensitive_keys:
+            result[key] = _redact(val)
+        else:
+            result[key] = val
+    return result
+
+
+def response(flow: http.HTTPFlow) -> None:
+    """Called when a response is received — log the full request/response pair."""
+    req = flow.request
+    resp = flow.response
+
+    event = {
+        "event": "intercept_request",
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
+        "method": req.method,
+        "url": req.pretty_url,
+        "host": req.host,
+        "port": req.port,
+        "path": req.path,
+        "request_headers": _safe_headers(req.headers),
+        "request_size": len(req.content) if req.content else 0,
+        "status_code": resp.status_code if resp else None,
+        "response_headers": _safe_headers(resp.headers) if resp else {},
+        "response_size": len(resp.content) if resp and resp.content else 0,
+        "duration_ms": int((flow.response.timestamp_end - flow.request.timestamp_start) * 1000)
+            if resp and hasattr(resp, 'timestamp_end') else None,
+    }
+
+    # Optionally capture bodies (can be very large)
+    if CAPTURE_BODIES:
+        if req.content:
+            try:
+                event["request_body"] = _redact(req.content.decode("utf-8", errors="replace")[:10000])
+            except Exception:
+                event["request_body"] = f"[binary, {len(req.content)} bytes]"
+        if resp and resp.content:
+            try:
+                event["response_body"] = resp.content.decode("utf-8", errors="replace")[:10000]
+            except Exception:
+                event["response_body"] = f"[binary, {len(resp.content)} bytes]"
+
+    with open(LOG_FILE, "a") as f:
+        f.write(json.dumps(event) + "\n")

--- a/scripts/intercept-start.sh
+++ b/scripts/intercept-start.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# intercept-start.sh — start the intercepting proxy for agent traffic capture
+#
+# Environment:
+#   CLIDE_INTERCEPT=1          Enable intercepting proxy (default: disabled)
+#   CLIDE_INTERCEPT_PORT=8080  Proxy listen port (default: 8080)
+#   CLIDE_INTERCEPT_BODIES=0   Capture request/response bodies (default: 0)
+#   CLIDE_LOG_DIR              Log directory (default: /workspace/.clide/logs)
+
+set -euo pipefail
+
+if [[ "${CLIDE_INTERCEPT:-0}" != "1" ]]; then
+  exit 0
+fi
+
+PORT="${CLIDE_INTERCEPT_PORT:-8080}"
+SCRIPT_DIR="$(dirname "$0")"
+ADDON="${SCRIPT_DIR}/intercept-proxy.py"
+if [[ ! -f "$ADDON" ]]; then
+  ADDON="/usr/local/bin/intercept-proxy.py"
+fi
+
+if ! command -v mitmdump >/dev/null 2>&1; then
+  echo "[intercept] ERROR: mitmdump not found. Install with: pip install mitmproxy"
+  exit 1
+fi
+
+echo "[intercept] Starting proxy on port ${PORT} (bodies=${CLIDE_INTERCEPT_BODIES:-0})"
+
+# Start mitmdump in background
+mitmdump \
+  --listen-port "$PORT" \
+  --set ssl_insecure=true \
+  --set block_global=false \
+  -s "$ADDON" \
+  --quiet &
+
+PROXY_PID=$!
+echo "[intercept] Proxy started (pid ${PROXY_PID})"
+
+# Export proxy env vars so child processes (claude, codex, etc.) use the proxy
+export HTTP_PROXY="http://127.0.0.1:${PORT}"
+export HTTPS_PROXY="http://127.0.0.1:${PORT}"
+export http_proxy="http://127.0.0.1:${PORT}"
+export https_proxy="http://127.0.0.1:${PORT}"
+
+# Write env vars to a file that session-logger can source
+ENV_FILE="/tmp/.clide-proxy-env"
+cat > "$ENV_FILE" << EOF
+export HTTP_PROXY=http://127.0.0.1:${PORT}
+export HTTPS_PROXY=http://127.0.0.1:${PORT}
+export http_proxy=http://127.0.0.1:${PORT}
+export https_proxy=http://127.0.0.1:${PORT}
+EOF
+
+echo "[intercept] Proxy env written to ${ENV_FILE}"
+echo "[intercept] Logs: \${CLIDE_LOG_DIR:-/workspace/.clide/logs}/intercept.jsonl"


### PR DESCRIPTION
## Summary
mitmproxy-based HTTP(S) interceptor for deep agent traffic analysis.

- **intercept-proxy.py** — mitmproxy addon that logs request/response metadata to JSONL
- **intercept-start.sh** — starts the proxy, exports HTTP(S)_PROXY env vars
- Auto-starts from `claude-entrypoint.sh` when `CLIDE_INTERCEPT=1`
- Secret redaction on API keys, tokens, auth headers
- Optional body capture with `CLIDE_INTERCEPT_BODIES=1`
- mitmproxy 11.1.3 added to Dockerfile (in pyenv)

### Example output
```json
{"event": "intercept_request", "method": "POST", "url": "https://api.anthropic.com/v1/messages",
 "host": "api.anthropic.com", "status_code": 200, "request_size": 4521, "response_size": 1893,
 "duration_ms": 2341, "request_headers": {"authorization": "[REDACTED:Bearer...]"}}
```

### Observability stack now
| Feature | Env var | Output |
|---------|---------|--------|
| Session logging | (always on) | events.jsonl + conversation.jsonl |
| Token/cost tracking | (always on) | session_end event |
| Egress audit | CLIDE_EGRESS_AUDIT=1 | egress.jsonl |
| **Intercept proxy** | **CLIDE_INTERCEPT=1** | **intercept.jsonl** |

Closes #50

## Test plan
- [ ] CI checks pass
- [ ] Build with mitmproxy doesn't bloat image excessively
- [ ] Claude session works with proxy enabled
- [ ] intercept.jsonl captures API calls with redacted secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)