### PR TITLE
fix: add pyenv + workspace tools to PATH in .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,5 +1,17 @@
 # shellcheck shell=bash
 
+# Ensure pyenv (pip, pytest, ruff) and workspace tools are on PATH.
+# Docker ENV PATH isn't always propagated through gosu → tmux → bash.
+export PATH="/home/clide/.local/bin:/opt/pyenv/bin:${PATH}"
+
+# Make workspace Python tools (sdale, clidetext) importable without pip install.
+# These are on the bind-mounted workspace so they stay current across rebuilds.
+for _tool_dir in /workspace/clide-sdale /workspace/clidetext; do
+  [[ -d "$_tool_dir" ]] && PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${_tool_dir}"
+done
+[[ -n "${PYTHONPATH:-}" ]] && export PYTHONPATH
+unset _tool_dir
+
 # Show splash on first interactive login (web terminal / tmux session).
 # Guard with CLIDE_SPLASH_SHOWN so it only prints once per session, not on
 # every new pane/window split.

--- a/README.md
+++ b/README.md
@@ -364,3 +364,11 @@ The venv is at `/opt/pyenv`; `pip`, `pytest`, and `ruff` are all directly callab
 `safe.directory = *` is pre-configured in the clide user's gitconfig at image build time. Volume-mounted repos cloned from GitHub are often owned by the host UID rather than `clide:1000`, which normally causes git to refuse to operate with a "detected dubious ownership" error. This is eliminated entirely — `git status`, `git log`, and all other git operations work from the first prompt without any `git config` boilerplate.
 
 > **Security note:** `safe.directory = *` trusts all directories unconditionally. This is appropriate for a single-user dev sandbox where you control what gets mounted, but it means git will operate in any directory regardless of ownership. If you share the container or mount untrusted paths, consider replacing `*` with the specific paths you use (e.g. `/workspace`).
+
+## Ecosystem
+
+| Project | What |
+|---------|------|
+| **clide** | CLI Development Environment (you are here) |
+| [clidesdale](https://github.com/itscooleric/clidesdale) | CLI client — SSH access to remote VPSes for agents |
+| [clidestable](https://github.com/itscooleric/clidestable) | VPS-side server — dashboard, stall management, split terminal view |


### PR DESCRIPTION
## Summary

- Add `/opt/pyenv/bin` to PATH in `.bashrc` so `pip`, `pytest`, `ruff` are available in interactive shells (Docker ENV PATH doesn't survive `gosu` → `tmux` → `bash`)
- Add PYTHONPATH entries for `/workspace/clide-sdale` and `/workspace/clidetext` so sdale and clidetext work without `pip install`

## Why

The pyenv venv with pip/pytest/ruff is already installed in the image (Dockerfile line 63-71) but the PATH wasn't making it to interactive shells. Agents had to discover the `PYTHONPATH=` workaround or fail silently.

## Test plan

- [x] Verified `pip`, `sdale`, `clidetext` all work after sourcing the updated `.bashrc`
- [ ] Rebuild clide image and confirm `pip --version` works in a fresh tmux session
- [ ] Confirm `python3 -m sdale list` works without any setup in a fresh session

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)