### PR TITLE
chore: standardize Makefile per SOP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 .env
 docker-compose.override.yml
+*.crt
+*.key
+*.pem
+__pycache__/
+*.pyc
+.DS_Store
+node_modules/
 
 # Session logs (generated at runtime inside workspace)
 .clide/logs/

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,85 @@
-.PHONY: build rebuild web web-stop cli logs status help
+# Makefile — clide compose + deploy helpers
+#
+# Common targets:
+#   make web          start web terminal (local dev)
+#   make cli          interactive shell
+#   make deploy       build + start with override (production)
+#   make logs         tail logs
+
+# ── Compose file sets ──────────────────────────────────────────────────────
+
+DC      := docker compose -f docker-compose.yml
+DC_FULL := docker compose -f docker-compose.yml -f docker-compose.override.yml
 
 # Derive version: branch@shorthash (YYYY-MM-DD)
 BUILD_VERSION := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "dev")@$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown") ($(shell date -u +%Y-%m-%d))
 export BUILD_VERSION
 
+# ── Help ───────────────────────────────────────────────────────────────────
+
+.PHONY: help
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-build: ## Build the clide image
-	BUILD_VERSION="$(BUILD_VERSION)" docker compose build
+.DEFAULT_GOAL := help
 
-rebuild: ## Rebuild the clide image (no cache)
-	BUILD_VERSION="$(BUILD_VERSION)" docker compose build --no-cache
+# ── Build ──────────────────────────────────────────────────────────────────
 
-web: ## Start web terminal at http://localhost:7681
-	@docker compose up -d web
+.PHONY: build build-override rebuild
+
+build: ## Build image (base compose)
+	BUILD_VERSION="$(BUILD_VERSION)" $(DC) build
+
+build-override: ## Build with override (production)
+	BUILD_VERSION="$(BUILD_VERSION)" $(DC_FULL) build
+
+rebuild: ## Rebuild image (no cache)
+	BUILD_VERSION="$(BUILD_VERSION)" $(DC) build --no-cache
+
+# ── Up / down ──────────────────────────────────────────────────────────────
+
+.PHONY: up up-override deploy down restart
+
+up: ## Start web terminal
+	$(DC) up -d web
+
+up-override: ## Start with override (production)
+	$(DC_FULL) up -d web
+
+deploy: ## Build + start with override (most common)
+	BUILD_VERSION="$(BUILD_VERSION)" $(DC_FULL) up -d --build web
+
+down: ## Stop services
+	$(DC_FULL) down 2>/dev/null || $(DC) down
+
+restart: ## Restart web terminal
+	$(DC) restart web
+
+# ── Clide-specific ─────────────────────────────────────────────────────────
+
+.PHONY: web cli
+
+web: up ## Start web terminal at http://localhost:7681
 	@echo ""
 	@echo "  Web terminal running at http://localhost:7681"
-	@echo "  Stop with: make web-stop"
+	@echo "  Stop with: make down"
 	@echo ""
 
-web-stop: ## Stop the web terminal
-	docker compose down
-
 cli: ## Open interactive shell (all CLIs available)
-	docker compose run --rm cli
+	$(DC) run --rm cli
 
-logs: ## Show web terminal logs
-	docker compose logs -f web
+# ── Logs / status ──────────────────────────────────────────────────────────
 
-status: ## Show running containers
+.PHONY: logs health shell ps
+
+logs: ## Tail logs (all services)
+	$(DC) logs -f --tail=50
+
+health: ## Health check
+	@curl -sf http://localhost:$${TTYD_PORT:-7681}/ > /dev/null && echo "healthy" || echo "unhealthy"
+
+shell: ## Shell into web container
+	docker exec -it $$(docker compose ps -q web) bash
+
+ps: ## Show running containers
 	docker compose ps


### PR DESCRIPTION
SOP standard targets: build, build-override, up, up-override, deploy, down, restart, logs, health, shell, ps, help. Keeps clide-specific web/cli targets. Updates .gitignore with __pycache__, *.pyc, cert patterns.